### PR TITLE
Add AyuGram to custom Telegram clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Telepost | ru.telepost.msg | TelegrApp
 فارسی برای تلگرام  | com.telegram.farsi | KEREMSOFT
 Mewati Telegram | com.wMewatiTelegram_786 | NishuTech Inc
 Ethiogram | com.etiogram.telegram.messenger.chat | andnetappsdev
-
+[Ayugram](https://github.com/AyuGram) | com.radolyn.ayugram | [Radolyn Labs](https://radolyn.com/) | ✅ Trusted


### PR DESCRIPTION
This adds AyuGram to the custom Telegram clients list with its package name and project links, using the existing table format.

The AyuGram GitHub organization is still reachable, and this PR remains mergeable against `master`.
